### PR TITLE
Add WezTerm to all docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Use it when you want:
 For splits and workspaces, use `tsm mux` to orchestrate your terminal's native split system:
 
 - `tsm mux open dev` opens a workspace with splits and sessions from a TOML manifest
-- supports **cmux**, **kitty**, and **Ghostty** as backends (auto-detected)
+- supports **cmux**, **kitty**, **Ghostty**, and **WezTerm** as backends (auto-detected)
 - each pane is a real native terminal surface with full GPU rendering, ligatures, scrollback
 - no VT re-emulation like tmux/zellij
 
@@ -106,8 +106,9 @@ tsm mux status                          Show terminal, backend, workspace info
 | cmux     | cmux    | `CMUX_SOCKET_PATH` | yes | yes | yes |
 | kitty    | kitty   | `KITTY_PID` | yes | yes | no |
 | Ghostty  | ghostty | `GHOSTTY_RESOURCES_DIR` | yes | yes | no |
+| WezTerm  | wezterm | `WEZTERM_UNIX_SOCKET` | yes | yes | no |
 
-Override with `TSM_MUX_BACKEND=cmux` (or `kitty`, `ghostty`).
+Override with `TSM_MUX_BACKEND=cmux` (or `kitty`, `ghostty`, `wezterm`).
 
 ### TUI workspace picker
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,7 @@ Each daemon also writes a small build-metadata sidecar. That lets newer clients 
 | `backend/cmux/` | cmux CLI wrapper backend |
 | `backend/kitty/` | kitty remote control backend (`kitten @`) |
 | `backend/ghostty/` | Ghostty AppleScript backend (macOS) |
+| `backend/wezterm/` | WezTerm CLI backend (`wezterm cli`) |
 
 ### `internal/tui`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -210,8 +210,9 @@ tsm mux status        # Show detected terminal and backend
 | cmux | `CMUX_SOCKET_PATH` | yes | yes | yes |
 | kitty | `KITTY_PID` | yes | yes | no |
 | Ghostty | `GHOSTTY_RESOURCES_DIR` | yes | yes | no |
+| WezTerm | `WEZTERM_UNIX_SOCKET` | yes | yes | no |
 
-Override with `TSM_MUX_BACKEND=cmux` (or `kitty`, `ghostty`).
+Override with `TSM_MUX_BACKEND=cmux` (or `kitty`, `ghostty`, `wezterm`).
 
 ## Diagnostics
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -78,6 +78,7 @@ Notes:
 | cmux | cmux | yes | yes | yes | macOS | `CMUX_SOCKET_PATH` |
 | kitty | kitty | yes | yes | no | macOS, Linux | `KITTY_PID` |
 | Ghostty | ghostty | yes | yes | no | macOS only | `GHOSTTY_RESOURCES_DIR` |
+| WezTerm | wezterm | yes | yes | no | macOS, Linux | `WEZTERM_UNIX_SOCKET` |
 | Alacritty | none | no | no | no | - | - |
 | Terminal.app | none | no | no | no | - | - |
 | iTerm2 | none | no | no | no | - | - |
@@ -86,6 +87,7 @@ Notes:
 
 - kitty requires `allow_remote_control yes` and `enabled_layouts splits,tall,stack` in kitty.conf (`tsm mux setup kitty`)
 - Ghostty requires 1.3.0+ and uses the AppleScript API (macOS only, preview feature)
+- WezTerm works out of the box — no config changes needed
 - cmux sidebar sync pushes session and agent (claude/codex) state
 - terminals without a backend can still use `tsm` for session management — splits are not required
 

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -4,7 +4,7 @@ This document describes the current product boundary for `tsm`.
 
 ## Session Manager with Native Multiplexer
 
-`tsm` manages long-lived terminal sessions. For splits and workspaces, `tsm mux` orchestrates your terminal emulator's native split system (cmux, kitty, or Ghostty).
+`tsm` manages long-lived terminal sessions. For splits and workspaces, `tsm mux` orchestrates your terminal emulator's native split system (cmux, kitty, Ghostty, or WezTerm).
 
 Unlike tmux/zellij, `tsm mux` does not re-emulate VT output. Each pane is a real native terminal surface. This means:
 
@@ -17,6 +17,7 @@ Current mux limitations:
 - cmux backend: `tsm mux` commands that create/modify layout require running from a non-attached cmux pane (cmux's default `cmuxOnly` socket mode blocks access from tsm session daemons)
 - kitty backend: requires `allow_remote_control yes` and `enabled_layouts splits,tall,stack` in kitty.conf
 - Ghostty backend: macOS only (uses AppleScript API), no `ReadScreen` support
+- WezTerm backend: works out of the box, no config changes needed
 - `tsm mux last` / `next` don't visually switch panes when run from a shell (pane navigation is best done via terminal keybindings)
 - Alacritty, Terminal.app, and iTerm2 have no split APIs and are not supported as mux backends
 


### PR DESCRIPTION
## Summary

- Add WezTerm to supported backends table in README
- Add `backend/wezterm/` to ARCHITECTURE.md package layout
- Add WezTerm row to CLI.md backends table
- Add WezTerm row to COMPATIBILITY.md mux backends matrix
- Add WezTerm note to KNOWN_LIMITATIONS.md

## Test plan

- [x] All docs mention WezTerm consistently
- [x] No code changes