### PR TITLE
fix: symlink fish conf.d, functions, completions into session config

### DIFF
--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -694,7 +694,9 @@ func ensureFishIntegration(cfg Config, name string, shortcuts shellShortcuts, or
 			src := filepath.Join(origFishDir, sub)
 			dst := filepath.Join(configDir, sub)
 			// Remove any stale symlink from a previous session.
-			os.Remove(dst)
+			if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+				return "", fmt.Errorf("remove stale fish %s: %w", sub, err)
+			}
 			if _, err := os.Stat(src); err == nil {
 				if err := os.Symlink(src, dst); err != nil {
 					return "", fmt.Errorf("symlink fish %s: %w", sub, err)

--- a/internal/session/daemon_test.go
+++ b/internal/session/daemon_test.go
@@ -236,6 +236,63 @@ func TestBuildDaemonEnvAddsFishIntegration(t *testing.T) {
 	}
 }
 
+func TestFishIntegrationSymlinksConfdFunctionsCompletions(t *testing.T) {
+	dir := t.TempDir()
+	xdg := filepath.Join(dir, "xdg")
+	fishDir := filepath.Join(xdg, "fish")
+
+	// Create the three subdirectories in the user's fish config.
+	for _, sub := range []string{"conf.d", "functions", "completions"} {
+		if err := os.MkdirAll(filepath.Join(fishDir, sub), 0750); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+	}
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	cfg := Config{SocketDir: t.TempDir()}
+	_, err := buildDaemonEnv(cfg, "symtest", "/opt/homebrew/bin/fish", nil)
+	if err != nil {
+		t.Fatalf("buildDaemonEnv: %v", err)
+	}
+
+	configDir := filepath.Join(shellIntegrationDir(cfg, "fish", "symtest"), "fish")
+	for _, sub := range []string{"conf.d", "functions", "completions"} {
+		link := filepath.Join(configDir, sub)
+		target, err := os.Readlink(link)
+		if err != nil {
+			t.Fatalf("readlink %s: %v", sub, err)
+		}
+		want := filepath.Join(fishDir, sub)
+		if target != want {
+			t.Fatalf("symlink %s points to %q, want %q", sub, target, want)
+		}
+	}
+}
+
+func TestFishIntegrationSkipsSymlinksWhenSubdirsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	xdg := filepath.Join(dir, "xdg")
+	// Create the fish dir but NOT conf.d/functions/completions.
+	if err := os.MkdirAll(filepath.Join(xdg, "fish"), 0750); err != nil {
+		t.Fatalf("mkdir xdg fish: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+
+	cfg := Config{SocketDir: t.TempDir()}
+	_, err := buildDaemonEnv(cfg, "nosubdirs", "/opt/homebrew/bin/fish", nil)
+	if err != nil {
+		t.Fatalf("buildDaemonEnv: %v", err)
+	}
+
+	configDir := filepath.Join(shellIntegrationDir(cfg, "fish", "nosubdirs"), "fish")
+	for _, sub := range []string{"conf.d", "functions", "completions"} {
+		link := filepath.Join(configDir, sub)
+		if _, err := os.Lstat(link); !os.IsNotExist(err) {
+			t.Fatalf("expected no symlink for %s when source absent, but got err=%v", sub, err)
+		}
+	}
+}
+
 func TestBuildDaemonEnvPreservesOriginalXDGInsideSession(t *testing.T) {
 	dir := t.TempDir()
 	orig := filepath.Join(dir, "orig-xdg")


### PR DESCRIPTION
## Summary

- tsm redirects `XDG_CONFIG_HOME` to inject its own `config.fish`, but the redirected directory only contains `config.fish` — the `conf.d/`, `functions/`, and `completions/` subdirectories from the user's original fish config are dropped
- This breaks plugins that install via `conf.d/` (e.g. **starship**, tide, fisher-managed plugins) and any custom functions or completions
- Fix: symlink these three subdirectories from the original `XDG_CONFIG_HOME/fish/` into tsm's per-session fish config directory

### Before
Fish sessions in tsm get the default fish prompt because `conf.d/` scripts (like starship's init) never load.

### After  
All `conf.d/` scripts, custom functions, and completions load normally. tsm's prompt marker still works via its generated `config.fish`.

## Test plan
- [ ] Create a tsm session with fish + starship — verify starship prompt renders
- [ ] Verify tsm `[tsm:name]` prefix still appears
- [ ] Test with custom fish functions in `~/.config/fish/functions/` — verify they're available
- [ ] Test with no `conf.d/` directory present — verify no error

🤖 Generated with [Claude Code](https://claude.com/claude-code)