### PR TITLE
feat: comprehensive git worktree support

### DIFF
--- a/internal/session/artifacts.go
+++ b/internal/session/artifacts.go
@@ -17,6 +17,7 @@ func RemoveSessionArtifacts(cfg Config, sessionName string) error {
 	paths := []string{
 		daemonBuildInfoPath(cfg, sessionName),
 		ClaudeStatuslinePath(cfg, sessionName),
+		GitMetaPath(cfg, sessionName),
 	}
 	for _, path := range paths {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
@@ -52,6 +53,7 @@ func RenameSessionArtifacts(cfg Config, oldName, newName string) error {
 	pairs := [][2]string{
 		{daemonBuildInfoPath(cfg, oldName), daemonBuildInfoPath(cfg, newName)},
 		{ClaudeStatuslinePath(cfg, oldName), ClaudeStatuslinePath(cfg, newName)},
+		{GitMetaPath(cfg, oldName), GitMetaPath(cfg, newName)},
 	}
 	for _, pair := range pairs {
 		if err := renameOptionalFile(pair[0], pair[1]); err != nil {
@@ -82,6 +84,7 @@ func ListSessionArtifacts(cfg Config) ([]SessionArtifact, error) {
 	sources := []source{
 		{kind: "daemon-build", dir: daemonBuildDir},
 		{kind: "claude-statusline", dir: claudeStatuslineDir},
+		{kind: "git-meta", dir: gitMetaDir},
 	}
 
 	var artifacts []SessionArtifact

--- a/internal/session/client.go
+++ b/internal/session/client.go
@@ -21,6 +21,10 @@ import (
 var kittyCtrlBackslash = []byte("\x1b[92;5u")
 var kittyCtrlBackslashExt = []byte("\x1b[92;5:")
 
+// Ctrl+] (0x1D) opens the session picker.
+var kittyCtrlBracket = []byte("\x1b[93;5u")
+var kittyCtrlBracketExt = []byte("\x1b[93;5:")
+
 // isDetachKey checks if the input contains the detach sequence:
 // either traditional Ctrl+\ (0x1C) or Kitty keyboard protocol encoding.
 func isDetachKey(data []byte) bool {
@@ -31,6 +35,25 @@ func isDetachKey(data []byte) bool {
 	}
 	return bytes.Contains(data, kittyCtrlBackslash) ||
 		bytes.Contains(data, kittyCtrlBackslashExt)
+}
+
+// isPickerKey checks if the input contains the picker sequence:
+// Ctrl+] (0x1D) or Kitty keyboard protocol encoding.
+func isPickerKey(data []byte) bool {
+	for _, b := range data {
+		if b == 0x1D {
+			return true
+		}
+	}
+	return bytes.Contains(data, kittyCtrlBracket) ||
+		bytes.Contains(data, kittyCtrlBracketExt)
+}
+
+// PickerRequestError is returned by Attach when the user requests the session picker.
+type PickerRequestError struct{}
+
+func (e *PickerRequestError) Error() string {
+	return "session picker requested"
 }
 
 // Terminal reset sequences sent before attach and on detach.
@@ -122,12 +145,18 @@ func Attach(cfg Config, name string) error {
 	}()
 
 	// Relay stdin → server input.
+	var pickerErr atomic.Pointer[PickerRequestError]
 	go func() {
 		defer closeDone()
 		buf := make([]byte, 4096)
 		for {
 			n, err := os.Stdin.Read(buf)
 			if n > 0 {
+				if isPickerKey(buf[:n]) {
+					pickerErr.Store(&PickerRequestError{})
+					SendMessage(conn, TagDetach, nil)
+					return
+				}
 				if isDetachKey(buf[:n]) {
 					SendMessage(conn, TagDetach, nil)
 					return
@@ -158,6 +187,9 @@ func Attach(cfg Config, name string) error {
 	conn.Close() // unblock any pending I/O on relay goroutines
 	if se := switchErr.Load(); se != nil {
 		return se
+	}
+	if pe := pickerErr.Load(); pe != nil {
+		return pe
 	}
 	return nil
 }

--- a/internal/session/daemon.go
+++ b/internal/session/daemon.go
@@ -165,6 +165,12 @@ func StartDaemon(name string, shellCmd []string) error {
 
 // SpawnDaemon starts a daemon in a new process (re-exec with --daemon flag).
 func SpawnDaemon(name string, shellCmd []string) error {
+	return SpawnDaemonInDir(name, shellCmd, "")
+}
+
+// SpawnDaemonInDir spawns a new daemon process. If dir is non-empty, the daemon
+// starts in that directory instead of the current working directory.
+func SpawnDaemonInDir(name string, shellCmd []string, dir string) error {
 	cfg := DefaultConfig()
 
 	// Check if session already exists.
@@ -190,6 +196,9 @@ func SpawnDaemon(name string, shellCmd []string) error {
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	cmd.Stdin = nil
+	if dir != "" {
+		cmd.Dir = dir
+	}
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("spawn daemon: %w", err)

--- a/internal/session/git.go
+++ b/internal/session/git.go
@@ -1,0 +1,102 @@
+package session
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GitContext holds git repository information detected from a working directory.
+type GitContext struct {
+	RepoName   string `json:"repo_name"`   // basename of the main repo
+	BranchName string `json:"branch_name"` // current branch or short SHA for detached HEAD
+	IsWorktree bool   `json:"is_worktree"` // true if cwd is a linked worktree
+	IsGitRepo  bool   `json:"is_git_repo"` // true if inside any git repo
+	RepoRoot   string `json:"repo_root"`   // absolute path to main worktree root
+}
+
+// DetectGitContext detects git repository context from the given directory.
+// It runs a single git rev-parse invocation and parses the output.
+func DetectGitContext(cwd string) GitContext {
+	out, err := exec.Command("git", "-C", cwd, "rev-parse",
+		"--show-toplevel", "--git-common-dir", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return GitContext{}
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 3 {
+		return GitContext{}
+	}
+
+	toplevel := strings.TrimSpace(lines[0])
+	gitCommonDir := strings.TrimSpace(lines[1])
+	branch := strings.TrimSpace(lines[2])
+
+	// Resolve gitCommonDir relative to toplevel if not absolute.
+	if !filepath.IsAbs(gitCommonDir) {
+		gitCommonDir = filepath.Join(toplevel, gitCommonDir)
+	}
+	gitCommonDir = filepath.Clean(gitCommonDir)
+
+	// Determine if this is a linked worktree.
+	// For linked worktrees, gitCommonDir points to <main-repo>/.git (the common dir),
+	// while for the main worktree, gitCommonDir equals <toplevel>/.git.
+	mainGitDir := filepath.Join(toplevel, ".git")
+	isWorktree := gitCommonDir != mainGitDir
+
+	// Derive repo name from the common git dir.
+	repoRoot := deriveRepoRoot(gitCommonDir)
+	repoName := filepath.Base(repoRoot)
+
+	// For bare repos, strip .git suffix from the name.
+	repoName = strings.TrimSuffix(repoName, ".git")
+	if repoName == "" || repoName == "." {
+		repoName = filepath.Base(toplevel)
+	}
+
+	// Handle detached HEAD — branch will be "HEAD".
+	if branch == "HEAD" {
+		short, err := exec.Command("git", "-C", cwd, "rev-parse", "--short", "HEAD").Output()
+		if err == nil {
+			branch = strings.TrimSpace(string(short))
+		}
+	}
+
+	return GitContext{
+		RepoName:   repoName,
+		BranchName: branch,
+		IsWorktree: isWorktree,
+		IsGitRepo:  true,
+		RepoRoot:   repoRoot,
+	}
+}
+
+// deriveRepoRoot determines the repository root directory from the git common dir.
+// For a normal repo, gitCommonDir is <repo>/.git, so we return <repo>.
+// For a bare repo, gitCommonDir is the bare repo dir itself.
+func deriveRepoRoot(gitCommonDir string) string {
+	if filepath.Base(gitCommonDir) == ".git" {
+		return filepath.Dir(gitCommonDir)
+	}
+	// Bare repo — the common dir is the repo root.
+	return gitCommonDir
+}
+
+// FormatSessionName returns a session name based on git context.
+// For worktrees: "repo@branch". Otherwise: just the repo name.
+func FormatSessionName(ctx GitContext) string {
+	if ctx.IsWorktree && ctx.BranchName != "" {
+		return SanitizeBranch(ctx.RepoName) + "@" + SanitizeBranch(ctx.BranchName)
+	}
+	return SanitizeBranch(ctx.RepoName)
+}
+
+// SanitizeBranch replaces characters that are invalid in session names.
+func SanitizeBranch(name string) string {
+	name = strings.TrimSpace(name)
+	name = strings.ReplaceAll(name, "/", "-")
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.ReplaceAll(name, "\t", "-")
+	return name
+}

--- a/internal/session/git_meta.go
+++ b/internal/session/git_meta.go
@@ -1,0 +1,56 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+func gitMetaDir(cfg Config) string {
+	return filepath.Join(cfg.LogDir, "git-meta")
+}
+
+// GitMetaPath returns the path to the git metadata sidecar file for a session.
+func GitMetaPath(cfg Config, sessionName string) string {
+	return filepath.Join(gitMetaDir(cfg), sessionName+".json")
+}
+
+// WriteGitMeta atomically writes git context as a JSON sidecar file.
+func WriteGitMeta(cfg Config, sessionName string, ctx GitContext) error {
+	dir := gitMetaDir(cfg)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	data, err := json.Marshal(ctx)
+	if err != nil {
+		return err
+	}
+	path := GitMetaPath(cfg, sessionName)
+	tmp, err := os.CreateTemp(dir, sessionName+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// ReadGitMeta reads git context from a JSON sidecar file.
+func ReadGitMeta(cfg Config, sessionName string) (GitContext, error) {
+	data, err := os.ReadFile(GitMetaPath(cfg, sessionName))
+	if err != nil {
+		return GitContext{}, err
+	}
+	var ctx GitContext
+	if err := json.Unmarshal(data, &ctx); err != nil {
+		return GitContext{}, err
+	}
+	return ctx, nil
+}

--- a/internal/session/git_meta_test.go
+++ b/internal/session/git_meta_test.go
@@ -1,0 +1,63 @@
+package session
+
+import (
+	"os"
+	"testing"
+)
+
+func TestWriteReadGitMeta(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		SocketDir: dir,
+		LogDir:    dir + ".logs",
+	}
+
+	ctx := GitContext{
+		RepoName:   "myrepo",
+		BranchName: "feature/login",
+		IsWorktree: true,
+		IsGitRepo:  true,
+		RepoRoot:   "/home/user/myrepo",
+	}
+
+	if err := WriteGitMeta(cfg, "test-session", ctx); err != nil {
+		t.Fatalf("WriteGitMeta failed: %v", err)
+	}
+
+	got, err := ReadGitMeta(cfg, "test-session")
+	if err != nil {
+		t.Fatalf("ReadGitMeta failed: %v", err)
+	}
+
+	if got.RepoName != ctx.RepoName {
+		t.Errorf("RepoName = %q, want %q", got.RepoName, ctx.RepoName)
+	}
+	if got.BranchName != ctx.BranchName {
+		t.Errorf("BranchName = %q, want %q", got.BranchName, ctx.BranchName)
+	}
+	if got.IsWorktree != ctx.IsWorktree {
+		t.Errorf("IsWorktree = %v, want %v", got.IsWorktree, ctx.IsWorktree)
+	}
+	if got.IsGitRepo != ctx.IsGitRepo {
+		t.Errorf("IsGitRepo = %v, want %v", got.IsGitRepo, ctx.IsGitRepo)
+	}
+	if got.RepoRoot != ctx.RepoRoot {
+		t.Errorf("RepoRoot = %q, want %q", got.RepoRoot, ctx.RepoRoot)
+	}
+}
+
+func TestReadGitMeta_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		SocketDir: dir,
+		LogDir:    dir + ".logs",
+	}
+
+	_, err := ReadGitMeta(cfg, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent sidecar")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected not-exist error, got: %v", err)
+	}
+}

--- a/internal/session/git_test.go
+++ b/internal/session/git_test.go
@@ -1,0 +1,78 @@
+package session
+
+import "testing"
+
+func TestSanitizeBranch(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"main", "main"},
+		{"feature/login", "feature-login"},
+		{"feature/deep/nested", "feature-deep-nested"},
+		{"with spaces", "with-spaces"},
+		{"with\ttabs", "with-tabs"},
+		{"  trimmed  ", "trimmed"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := SanitizeBranch(tt.input)
+		if got != tt.want {
+			t.Errorf("SanitizeBranch(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatSessionName(t *testing.T) {
+	tests := []struct {
+		name string
+		ctx  GitContext
+		want string
+	}{
+		{
+			name: "worktree with branch",
+			ctx:  GitContext{RepoName: "myrepo", BranchName: "feature/login", IsWorktree: true, IsGitRepo: true},
+			want: "myrepo@feature-login",
+		},
+		{
+			name: "worktree with simple branch",
+			ctx:  GitContext{RepoName: "myrepo", BranchName: "main", IsWorktree: true, IsGitRepo: true},
+			want: "myrepo@main",
+		},
+		{
+			name: "non-worktree returns repo name",
+			ctx:  GitContext{RepoName: "myrepo", BranchName: "main", IsWorktree: false, IsGitRepo: true},
+			want: "myrepo",
+		},
+		{
+			name: "worktree without branch",
+			ctx:  GitContext{RepoName: "myrepo", BranchName: "", IsWorktree: true, IsGitRepo: true},
+			want: "myrepo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatSessionName(tt.ctx)
+			if got != tt.want {
+				t.Errorf("FormatSessionName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveRepoRoot(t *testing.T) {
+	tests := []struct {
+		gitCommonDir string
+		want         string
+	}{
+		{"/home/user/myrepo/.git", "/home/user/myrepo"},
+		{"/home/user/bare-repo.git", "/home/user/bare-repo.git"},
+		{"/home/user/myrepo", "/home/user/myrepo"},
+	}
+	for _, tt := range tests {
+		got := deriveRepoRoot(tt.gitCommonDir)
+		if got != tt.want {
+			t.Errorf("deriveRepoRoot(%q) = %q, want %q", tt.gitCommonDir, got, tt.want)
+		}
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -50,6 +50,10 @@ type Session struct {
 	AgentOutputStyle  string
 	AgentProjectDir   string
 	AgentWorktreePath string
+	GitRepoName       string
+	GitBranchName     string
+	GitIsWorktree     bool
+	GitRepoRoot       string
 	CreatedAt         uint64
 	TaskEndedAt       uint64
 	TaskExitCode      uint8
@@ -91,7 +95,7 @@ func ListSessions(cfg Config) ([]Session, error) {
 			continue
 		}
 
-		sessions = append(sessions, Session{
+		s := Session{
 			Name:         entry.Name(),
 			PID:          strconv.Itoa(int(info.PID)),
 			Clients:      int(info.ClientsLen),
@@ -100,7 +104,14 @@ func ListSessions(cfg Config) ([]Session, error) {
 			CreatedAt:    info.CreatedAt,
 			TaskEndedAt:  info.TaskEndedAt,
 			TaskExitCode: info.TaskExitCode,
-		})
+		}
+		if meta, err := ReadGitMeta(cfg, entry.Name()); err == nil {
+			s.GitRepoName = meta.RepoName
+			s.GitBranchName = meta.BranchName
+			s.GitIsWorktree = meta.IsWorktree
+			s.GitRepoRoot = meta.RepoRoot
+		}
+		sessions = append(sessions, s)
 	}
 
 	return sessions, nil

--- a/internal/tui/model_core.go
+++ b/internal/tui/model_core.go
@@ -43,6 +43,7 @@ const (
 	sortByPID
 	sortByMemory
 	sortByUptime
+	sortByRepo
 	sortModeCount
 )
 
@@ -58,8 +59,19 @@ func (s sortMode) label() string {
 		return "memory"
 	case sortByUptime:
 		return "uptime"
+	case sortByRepo:
+		return "repo"
 	}
 	return ""
+}
+
+// listEntry represents a row in the grouped session list.
+type listEntry struct {
+	IsHeader  bool
+	GroupName string
+	Count     int     // number of sessions in group (only for headers)
+	Collapsed bool    // whether this group is collapsed
+	Session   Session // only valid when !IsHeader
 }
 
 // Messages
@@ -232,6 +244,14 @@ type Model struct {
 	visibleMetrics    listMetrics
 	allMetrics        listMetrics
 	allMetricsDirty   bool
+
+	// Grouped view state
+	collapsed         map[string]bool // repo name → collapsed
+	entriesCache      []listEntry
+	entriesCacheDirty bool
+
+	currentSession      string // session name we're inside ($TSM_SESSION)
+	initialCursorPlaced bool   // true after first cursor placement
 }
 
 type listMetrics struct {
@@ -248,9 +268,12 @@ func initialModel() Model {
 		options:           normed,
 		normalizedOpts:    normed,
 		selected:          make(map[string]bool),
+		collapsed:         make(map[string]bool),
+		sortMode:          sortByRepo,
 		sortAsc:           true,
 		visibleCacheDirty: true,
 		allMetricsDirty:   true,
+		entriesCacheDirty: true,
 	}
 }
 
@@ -260,6 +283,7 @@ func NewModel(opts ...Options) Model {
 		normed := NormalizeOptions(opts[0])
 		m.options = normed
 		m.normalizedOpts = normed
+		m.currentSession = opts[0].CurrentSession
 	}
 	return m
 }
@@ -306,10 +330,12 @@ func (m *Model) visibleSessions() []Session {
 func (m *Model) markSessionsChanged() {
 	m.visibleCacheDirty = true
 	m.allMetricsDirty = true
+	m.entriesCacheDirty = true
 }
 
 func (m *Model) markVisibleChanged() {
 	m.visibleCacheDirty = true
+	m.entriesCacheDirty = true
 }
 
 func (m *Model) allSessionMetrics() listMetrics {
@@ -321,15 +347,28 @@ func (m *Model) allSessionMetrics() listMetrics {
 }
 
 func (m *Model) computeVisibleSessions() []Session {
+	// Start with all sessions, optionally restricted to a repo.
+	source := m.sessions
+	if m.normalizedOpts.FilterRepo != "" {
+		source = nil
+		for _, s := range m.sessions {
+			if s.GitRepoName == m.normalizedOpts.FilterRepo {
+				source = append(source, s)
+			}
+		}
+	}
+
 	var filtered []Session
 	if m.filterText == "" {
-		filtered = make([]Session, len(m.sessions))
-		copy(filtered, m.sessions)
+		filtered = make([]Session, len(source))
+		copy(filtered, source)
 	} else {
 		lower := strings.ToLower(m.filterText)
-		for _, s := range m.sessions {
+		for _, s := range source {
 			if strings.Contains(strings.ToLower(s.Name), lower) ||
-				strings.Contains(strings.ToLower(s.StartedIn), lower) {
+				strings.Contains(strings.ToLower(s.StartedIn), lower) ||
+				strings.Contains(strings.ToLower(s.GitBranchName), lower) ||
+				strings.Contains(strings.ToLower(s.GitRepoName), lower) {
 				filtered = append(filtered, s)
 			}
 		}
@@ -373,6 +412,21 @@ func (m *Model) computeVisibleSessions() []Session {
 				return dir * (a.Uptime - b.Uptime)
 			}
 			return cmp.Compare(a.Name, b.Name)
+		})
+	case sortByRepo:
+		slices.SortFunc(filtered, func(a, b Session) int {
+			ar, br := a.GitRepoName, b.GitRepoName
+			if ar != br {
+				// Sessions without a repo sort to the end.
+				if ar == "" {
+					return 1
+				}
+				if br == "" {
+					return -1
+				}
+				return dir * cmp.Compare(ar, br)
+			}
+			return dir * cmp.Compare(a.Name, b.Name)
 		})
 	}
 
@@ -520,6 +574,18 @@ func (m Model) listContentHeight(helpLines int) int {
 
 // clampCursor ensures cursor and listOffset are valid for the visible list.
 func (m *Model) clampCursor() {
+	if m.isGroupedMode() {
+		entries := m.visibleEntries()
+		if m.cursor >= len(entries) {
+			m.cursor = max(0, len(entries)-1)
+		}
+		// Skip to nearest non-header if landed on one.
+		m.skipHeaderForward(entries)
+		if m.listOffset > m.cursor {
+			m.listOffset = m.cursor
+		}
+		return
+	}
 	visible := m.visibleSessions()
 	if m.cursor >= len(visible) {
 		m.cursor = max(0, len(visible)-1)
@@ -527,6 +593,169 @@ func (m *Model) clampCursor() {
 	if m.listOffset > m.cursor {
 		m.listOffset = m.cursor
 	}
+}
+
+func (m Model) isGroupedMode() bool {
+	return m.sortMode == sortByRepo && !m.isSimplified()
+}
+
+// visibleEntries returns the flat list of entries (headers + sessions) for grouped view.
+func (m *Model) visibleEntries() []listEntry {
+	if !m.entriesCacheDirty {
+		return m.entriesCache
+	}
+	sessions := m.visibleSessions()
+	if !m.isGroupedMode() {
+		entries := make([]listEntry, len(sessions))
+		for i, s := range sessions {
+			entries[i] = listEntry{Session: s}
+		}
+		m.entriesCache = entries
+		m.entriesCacheDirty = false
+		return entries
+	}
+	m.entriesCache = groupByRepo(sessions, m.collapsed)
+	m.entriesCacheDirty = false
+	return m.entriesCache
+}
+
+// groupByRepo groups sessions by git repo name with header entries.
+func groupByRepo(sessions []Session, collapsed map[string]bool) []listEntry {
+	// Collect groups preserving sort order.
+	type group struct {
+		name     string
+		sessions []Session
+	}
+	var groups []group
+	groupIdx := map[string]int{}
+
+	var ungrouped []Session
+	for _, s := range sessions {
+		repo := s.GitRepoName
+		if repo == "" {
+			ungrouped = append(ungrouped, s)
+			continue
+		}
+		if idx, ok := groupIdx[repo]; ok {
+			groups[idx].sessions = append(groups[idx].sessions, s)
+		} else {
+			groupIdx[repo] = len(groups)
+			groups = append(groups, group{name: repo, sessions: []Session{s}})
+		}
+	}
+
+	var entries []listEntry
+	for _, g := range groups {
+		if len(g.sessions) == 1 {
+			// Single session — show flat, no header.
+			entries = append(entries, listEntry{Session: g.sessions[0]})
+			continue
+		}
+		isCollapsed := collapsed[g.name]
+		entries = append(entries, listEntry{
+			IsHeader:  true,
+			GroupName: g.name,
+			Count:     len(g.sessions),
+			Collapsed: isCollapsed,
+		})
+		if !isCollapsed {
+			for _, s := range g.sessions {
+				entries = append(entries, listEntry{Session: s})
+			}
+		}
+	}
+	for _, s := range ungrouped {
+		entries = append(entries, listEntry{Session: s})
+	}
+	return entries
+}
+
+// skipHeaderForward moves cursor past any header entry.
+func (m *Model) skipHeaderForward(entries []listEntry) {
+	for m.cursor < len(entries) && entries[m.cursor].IsHeader {
+		m.cursor++
+	}
+	if m.cursor >= len(entries) && len(entries) > 0 {
+		// Went past end, try backwards.
+		m.cursor = len(entries) - 1
+		for m.cursor > 0 && entries[m.cursor].IsHeader {
+			m.cursor--
+		}
+	}
+}
+
+// entrySession returns the session at the cursor position in grouped mode,
+// falling back to the flat visible list.
+func (m *Model) cursorSession() (Session, bool) {
+	if m.isGroupedMode() {
+		entries := m.visibleEntries()
+		if m.cursor < len(entries) && !entries[m.cursor].IsHeader {
+			return entries[m.cursor].Session, true
+		}
+		return Session{}, false
+	}
+	visible := m.visibleSessions()
+	if m.cursor < len(visible) {
+		return visible[m.cursor], true
+	}
+	return Session{}, false
+}
+
+// cursorGroupName returns the group name at the cursor (header or child).
+func (m *Model) cursorGroupName() string {
+	if !m.isGroupedMode() {
+		return ""
+	}
+	entries := m.visibleEntries()
+	if m.cursor >= len(entries) {
+		return ""
+	}
+	if entries[m.cursor].IsHeader {
+		return entries[m.cursor].GroupName
+	}
+	// Walk backwards to find the header.
+	for i := m.cursor - 1; i >= 0; i-- {
+		if entries[i].IsHeader {
+			return entries[i].GroupName
+		}
+	}
+	return ""
+}
+
+// placeCursorOnSession moves the cursor to the entry matching the given session name.
+func (m *Model) placeCursorOnSession(name string) {
+	if m.isGroupedMode() {
+		entries := m.visibleEntries()
+		for i, e := range entries {
+			if !e.IsHeader && e.Session.Name == name {
+				m.cursor = i
+				m.ensureVisible()
+				return
+			}
+		}
+	} else {
+		for i, s := range m.visibleSessions() {
+			if s.Name == name {
+				m.cursor = i
+				m.ensureVisible()
+				return
+			}
+		}
+	}
+}
+
+// visibleCount returns the number of selectable (non-header) entries.
+func (m *Model) visibleCount() int {
+	if m.isGroupedMode() {
+		count := 0
+		for _, e := range m.visibleEntries() {
+			if !e.IsHeader {
+				count++
+			}
+		}
+		return count
+	}
+	return len(m.visibleSessions())
 }
 
 func (m Model) Init() tea.Cmd {
@@ -539,9 +768,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
-		visible := m.visibleSessions()
-		if !m.isSimplified() && m.cursor < len(visible) {
-			return m, m.previewCmd()
+		if !m.isSimplified() {
+			if _, ok := m.cursorSession(); ok {
+				return m, m.previewCmd()
+			}
 		}
 
 	case sessionsMsg:
@@ -575,10 +805,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		m.clampCursor()
+		// On first load, place cursor on the current session.
+		if !m.initialCursorPlaced && m.currentSession != "" {
+			m.initialCursorPlaced = true
+			m.placeCursorOnSession(m.currentSession)
+		}
 		cmds := []tea.Cmd{fetchProcessInfoCmd(m.sessions)}
-		visible := m.visibleSessions()
-		if !m.isSimplified() && len(visible) > 0 && m.cursor < len(visible) {
-			if visible[m.cursor].AgentKind == "" {
+		if !m.isSimplified() {
+			if s, ok := m.cursorSession(); ok && s.AgentKind == "" {
 				cmds = append(cmds, m.previewCmd())
 			}
 		} else {
@@ -605,8 +839,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case previewMsg:
-		visible := m.visibleSessions()
-		if m.cursor < len(visible) && visible[m.cursor].Name == msg.name {
+		if s, ok := m.cursorSession(); ok && s.Name == msg.name {
 			m.preview = msg.content
 		}
 
@@ -693,11 +926,10 @@ func (m *Model) previewCmd() tea.Cmd {
 	if m.isSimplified() {
 		return nil
 	}
-	visible := m.visibleSessions()
-	if m.cursor >= len(visible) {
-		return nil
+	if s, ok := m.cursorSession(); ok {
+		return fetchPreviewCmd(s.Name, m.mainContentHeight(1))
 	}
-	return fetchPreviewCmd(visible[m.cursor].Name, m.mainContentHeight(1))
+	return nil
 }
 
 func (m *Model) killTargets() []string {
@@ -716,9 +948,8 @@ func (m *Model) actionTargets() []string {
 		}
 		return names
 	}
-	visible := m.visibleSessions()
-	if m.cursor < len(visible) {
-		return []string{visible[m.cursor].Name}
+	if s, ok := m.cursorSession(); ok {
+		return []string{s.Name}
 	}
 	return nil
 }

--- a/internal/tui/model_input.go
+++ b/internal/tui/model_input.go
@@ -62,7 +62,14 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	switch {
 	case m.isMoveUpKey(msg):
-		if m.cursor > 0 {
+		if m.isGroupedMode() {
+			if m.cursor > 0 {
+				m.cursor--
+				m.previewScrollX = 0
+				m.ensureVisible()
+				return m, m.previewCmd()
+			}
+		} else if m.cursor > 0 {
 			m.cursor--
 			m.previewScrollX = 0
 			m.ensureVisible()
@@ -70,7 +77,15 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case m.isMoveDownKey(msg):
-		if m.cursor < len(visible)-1 {
+		if m.isGroupedMode() {
+			entries := m.visibleEntries()
+			if m.cursor < len(entries)-1 {
+				m.cursor++
+				m.previewScrollX = 0
+				m.ensureVisible()
+				return m, m.previewCmd()
+			}
+		} else if m.cursor < len(visible)-1 {
 			m.cursor++
 			m.previewScrollX = 0
 			m.ensureVisible()
@@ -78,6 +93,22 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case m.isMoveLeftKey(msg):
+		// In grouped mode, left collapses the current group.
+		if m.isGroupedMode() {
+			if group := m.cursorGroupName(); group != "" && !m.collapsed[group] {
+				// Find the header index for this group so cursor lands on it.
+				entries := m.visibleEntries()
+				for i, e := range entries {
+					if e.IsHeader && e.GroupName == group {
+						m.cursor = i
+						break
+					}
+				}
+				m.collapsed[group] = true
+				m.entriesCacheDirty = true
+				return m, nil
+			}
+		}
 		if m.previewScrollX > 0 {
 			m.previewScrollX -= 4
 			if m.previewScrollX < 0 {
@@ -86,6 +117,18 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case m.isMoveRightKey(msg):
+		// In grouped mode, right expands a collapsed group.
+		if m.isGroupedMode() {
+			entries := m.visibleEntries()
+			if m.cursor < len(entries) && entries[m.cursor].IsHeader && entries[m.cursor].Collapsed {
+				group := entries[m.cursor].GroupName
+				m.collapsed[group] = false
+				m.entriesCacheDirty = true
+				// Move cursor to first child.
+				m.cursor++
+				return m, m.previewCmd()
+			}
+		}
 		maxW := previewMaxWidth(m.preview)
 		limit := maxW - m.previewInnerWidth()
 		if limit < 0 {
@@ -98,18 +141,33 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case m.isToggleSelectKey(msg):
-		if m.cursor < len(visible) {
-			name := visible[m.cursor].Name
-			if m.selected[name] {
-				delete(m.selected, name)
+		if s, ok := m.cursorSession(); ok {
+			if m.selected[s.Name] {
+				delete(m.selected, s.Name)
 			} else {
-				m.selected[name] = true
+				m.selected[s.Name] = true
 			}
 		}
 
 	case m.isAttachKey(msg):
-		if m.cursor < len(visible) {
-			m.attachTarget = visible[m.cursor].Name
+		// Enter on a header toggles collapse.
+		if m.isGroupedMode() {
+			entries := m.visibleEntries()
+			if m.cursor < len(entries) && entries[m.cursor].IsHeader {
+				group := entries[m.cursor].GroupName
+				if m.collapsed[group] {
+					m.collapsed[group] = false
+					m.entriesCacheDirty = true
+					m.cursor++ // move to first child
+				} else {
+					m.collapsed[group] = true
+					m.entriesCacheDirty = true
+				}
+				return m, nil
+			}
+		}
+		if s, ok := m.cursorSession(); ok {
+			m.attachTarget = s.Name
 			return m, tea.Quit
 		}
 
@@ -132,9 +190,8 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, tea.Batch(cmds...)
 		case m.isCopyKey(msg):
-			if m.cursor < len(visible) {
-				name := visible[m.cursor].Name
-				text := fmt.Sprintf("tsm attach %s", name)
+			if s, ok := m.cursorSession(); ok {
+				text := fmt.Sprintf("tsm attach %s", s.Name)
 				if err := engine.CopyToClipboard(text); err != nil {
 					m.status = fmt.Sprintf("Copy failed: %v", err)
 					m.addLog(confirmStyle.Render(fmt.Sprintf("  ✗ Copy failed: %v", err)))
@@ -148,10 +205,10 @@ func (m Model) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.state = stateNewSession
 			m.newSessionName = ""
 		case m.isRenameKey(msg):
-			if m.cursor < len(visible) {
+			if s, ok := m.cursorSession(); ok {
 				m.state = stateRenameSession
-				m.renameOldName = visible[m.cursor].Name
-				m.renameNewName = visible[m.cursor].Name
+				m.renameOldName = s.Name
+				m.renameNewName = s.Name
 			}
 		case m.isRefreshKey(msg):
 			m.refreshing = true

--- a/internal/tui/model_view.go
+++ b/internal/tui/model_view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"unicode/utf8"
 
@@ -138,8 +139,16 @@ func (m Model) fullView() tea.View {
 	// --- Preview pane ---
 	pw := m.previewInnerWidth()
 	selected := Session{}
-	if m.cursor < len(visible) {
-		selected = visible[m.cursor]
+	onHeader := false
+	headerName := ""
+	if s, ok := m.cursorSession(); ok {
+		selected = s
+	} else if m.isGroupedMode() {
+		entries := m.visibleEntries()
+		if m.cursor < len(entries) && entries[m.cursor].IsHeader {
+			onHeader = true
+			headerName = entries[m.cursor].GroupName
+		}
 	}
 	previewContent := ""
 	previewTitleLeft := " Preview "
@@ -156,12 +165,23 @@ func (m Model) fullView() tea.View {
 			lines = append(lines, prefix+name)
 		}
 		previewContent = clampLines(strings.Join(lines, "\n"), ch)
+	} else if onHeader {
+		previewTitleLeft = fmt.Sprintf(" %s ", headerName)
+		previewTitleRight = ""
+		previewContent = clampLines(m.renderGroupPreview(headerName, pw), ch)
 	} else if selected.AgentKind != "" {
 		previewContent = m.renderAgentPreview(selected, pw, ch)
+	} else if selected.Name != "" && selected.Name == os.Getenv("TSM_SESSION") {
+		// Current session — show info instead of terminal preview to avoid infinite mirror.
+		var lines []string
+		lines = append(lines, agentStateStyle.Render("(current session)"))
+		lines = append(lines, "")
+		lines = appendSection(lines, "overview", renderOverviewRows(selected))
+		previewContent = clampLines(strings.Join(lines, "\n"), ch)
 	} else {
 		previewContent = clampLines(engine.ScrollPreview(m.preview, m.previewScrollX, pw), ch)
 	}
-	if m.state != stateMuxOpen {
+	if m.state != stateMuxOpen && !onHeader {
 		if selected.Name != "" {
 			previewTitleLeft = fmt.Sprintf(" %s ", selected.Name)
 			previewTitleRight = fmt.Sprintf(" 📂 %s ", selected.DisplayDir())
@@ -225,9 +245,8 @@ func (m Model) simplifiedView() tea.View {
 
 	rowsHeight := m.simplifiedRowsHeight()
 	selected := Session{}
-	visible := m.visibleSessions()
-	if m.cursor < len(visible) {
-		selected = visible[m.cursor]
+	if s, ok := m.cursorSession(); ok {
+		selected = s
 	}
 	agentLine := m.renderAgentStatusLine(selected, innerWidth)
 	contentHeight := rowsHeight + 1
@@ -450,6 +469,10 @@ func (m Model) renderLog() string {
 }
 
 func (m *Model) renderList(maxRows int) string {
+	if m.isGroupedMode() {
+		return m.renderGroupedList(maxRows)
+	}
+
 	visible := m.visibleSessions()
 	if len(visible) == 0 {
 		if m.filterText != "" {
@@ -472,60 +495,7 @@ func (m *Model) renderList(maxRows int) string {
 		isCursor := i == m.cursor
 		isSelected := m.selected[s.Name]
 
-		var indicator string
-		switch {
-		case isCursor && isSelected:
-			indicator = selectedStyle.Render("▸●")
-		case isCursor:
-			indicator = selectedStyle.Render("▸ ")
-		case isSelected:
-			indicator = selectedStyle.Render(" ●")
-		default:
-			indicator = "  "
-		}
-
-		var clientInd string
-		if s.Clients > 0 {
-			clientInd = activeClientStyle.Render(padLeft(fmt.Sprintf("●%d", s.Clients), metrics.clientW))
-		} else {
-			clientInd = inactiveClientStyle.Render(padLeft("○0", metrics.clientW))
-		}
-
-		pidStr := pidStyle.Render(padLeft(s.PID, metrics.pidW))
-
-		memLabel := "-"
-		if s.Memory > 0 {
-			memLabel = engine.FormatBytes(s.Memory)
-		}
-		memStr := memStyle.Render(padLeft(memLabel, metrics.memW))
-
-		uptimeLabel := "-"
-		if s.Uptime > 0 {
-			uptimeLabel = engine.FormatUptime(s.Uptime)
-		}
-		uptimeStr := uptimeStyle.Render(padLeft(uptimeLabel, metrics.uptimeW))
-
-		// lw = indicator(2) + name + " " + pid + " " + mem + " " + uptime + " " + client
-		nameWidth := lw - 6 - metrics.pidW - metrics.memW - metrics.uptimeW - metrics.clientW
-		if nameWidth < 10 {
-			nameWidth = 10
-		}
-		name := truncate(s.Name, nameWidth)
-		paddedName := padRight(name, nameWidth)
-
-		style := normalStyle
-		if isCursor || isSelected {
-			style = selectedStyle
-		}
-
-		var styledName string
-		if m.filterText != "" {
-			styledName = highlightMatch(paddedName, m.filterText, style, filterMatchStyle)
-		} else {
-			styledName = style.Render(paddedName)
-		}
-
-		row := fmt.Sprintf("%s%s %s %s %s %s", indicator, styledName, pidStr, memStr, uptimeStr, clientInd)
+		row := m.renderSessionRow(s, isCursor, isSelected, lw, metrics, "")
 		b.WriteString(row)
 		if i < end-1 {
 			b.WriteString("\n")
@@ -533,6 +503,137 @@ func (m *Model) renderList(maxRows int) string {
 	}
 
 	return b.String()
+}
+
+func (m *Model) renderGroupedList(maxRows int) string {
+	entries := m.visibleEntries()
+	if len(entries) == 0 {
+		if m.filterText != "" {
+			return normalStyle.Render("  No matches. Esc to clear filter.")
+		}
+		return normalStyle.Render("  No sessions found. Press " + m.refreshKeyLabel() + " to refresh.")
+	}
+
+	lw := m.listInnerWidth()
+	metrics := m.visibleMetrics
+	var b strings.Builder
+
+	end := m.listOffset + maxRows
+	if end > len(entries) {
+		end = len(entries)
+	}
+
+	for i := m.listOffset; i < end; i++ {
+		e := entries[i]
+		if e.IsHeader {
+			chevron := "▾"
+			if e.Collapsed {
+				chevron = "▸"
+			}
+			header := fmt.Sprintf("  %s %s (%d)", chevron, e.GroupName, e.Count)
+			if len(header) < lw {
+				header = padRight(header, lw)
+			}
+			if i == m.cursor {
+				b.WriteString(selectedStyle.Render(header))
+			} else {
+				b.WriteString(groupHeaderStyle.Render(header))
+			}
+		} else {
+			isCursor := i == m.cursor
+			isSelected := m.selected[e.Session.Name]
+			row := m.renderSessionRow(e.Session, isCursor, isSelected, lw, metrics, "  ")
+			b.WriteString(row)
+		}
+		if i < end-1 {
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+func (m *Model) renderSessionRow(s Session, isCursor, isSelected bool, lw int, metrics listMetrics, indent string) string {
+	var indicator string
+	switch {
+	case isCursor && isSelected:
+		indicator = selectedStyle.Render("▸●")
+	case isCursor:
+		indicator = selectedStyle.Render("▸ ")
+	case isSelected:
+		indicator = selectedStyle.Render(" ●")
+	default:
+		indicator = "  "
+	}
+
+	var clientInd string
+	if s.Clients > 0 {
+		clientInd = activeClientStyle.Render(padLeft(fmt.Sprintf("●%d", s.Clients), metrics.clientW))
+	} else {
+		clientInd = inactiveClientStyle.Render(padLeft("○0", metrics.clientW))
+	}
+
+	pidStr := pidStyle.Render(padLeft(s.PID, metrics.pidW))
+
+	memLabel := "-"
+	if s.Memory > 0 {
+		memLabel = engine.FormatBytes(s.Memory)
+	}
+	memStr := memStyle.Render(padLeft(memLabel, metrics.memW))
+
+	uptimeLabel := "-"
+	if s.Uptime > 0 {
+		uptimeLabel = engine.FormatUptime(s.Uptime)
+	}
+	uptimeStr := uptimeStyle.Render(padLeft(uptimeLabel, metrics.uptimeW))
+
+	// lw = indicator(2) + indent + name + " " + pid + " " + mem + " " + uptime + " " + client
+	nameWidth := lw - 6 - len(indent) - metrics.pidW - metrics.memW - metrics.uptimeW - metrics.clientW
+	if nameWidth < 10 {
+		nameWidth = 10
+	}
+
+	displayName := s.Name
+	// For non-worktree git sessions, append branch as a dim suffix.
+	branchSuffix := ""
+	if s.GitBranchName != "" && !s.GitIsWorktree && !strings.Contains(s.Name, "@") {
+		branchSuffix = " " + s.GitBranchName
+	}
+
+	name := truncate(displayName, nameWidth)
+	// Calculate remaining space for branch suffix.
+	remaining := nameWidth - runewidth.StringWidth(name)
+	if branchSuffix != "" && remaining > 3 {
+		branchSuffix = truncate(branchSuffix, remaining)
+	} else {
+		branchSuffix = ""
+	}
+
+	paddedName := padRight(name+branchSuffix, nameWidth)
+
+	style := normalStyle
+	if isCursor || isSelected {
+		style = selectedStyle
+	}
+
+	var styledName string
+	if branchSuffix != "" {
+		// Render name and branch suffix separately for different styling.
+		nameOnly := padRight(name, nameWidth-runewidth.StringWidth(branchSuffix))
+		if m.filterText != "" {
+			styledName = highlightMatch(nameOnly, m.filterText, style, filterMatchStyle) + branchStyle.Render(branchSuffix)
+		} else {
+			styledName = style.Render(nameOnly) + branchStyle.Render(branchSuffix)
+		}
+	} else {
+		if m.filterText != "" {
+			styledName = highlightMatch(paddedName, m.filterText, style, filterMatchStyle)
+		} else {
+			styledName = style.Render(paddedName)
+		}
+	}
+
+	return fmt.Sprintf("%s%s%s %s %s %s %s", indent, indicator, styledName, pidStr, memStr, uptimeStr, clientInd)
 }
 
 func (m *Model) renderPaletteList(maxRows, innerWidth int) string {
@@ -586,11 +687,36 @@ func (m *Model) renderPaletteList(maxRows, innerWidth int) string {
 		if isCursor || isSelected {
 			style = selectedStyle
 		}
-		name := truncate(s.Name, nameWidth)
-		paddedName := padRight(name, nameWidth)
-		styledName := style.Render(paddedName)
-		if m.filterText != "" {
-			styledName = highlightMatch(paddedName, m.filterText, style, filterMatchStyle)
+
+		displayName := s.Name
+		branchSuffix := ""
+		if s.GitBranchName != "" && !s.GitIsWorktree && !strings.Contains(s.Name, "@") {
+			branchSuffix = " " + s.GitBranchName
+		}
+
+		name := truncate(displayName, nameWidth)
+		remaining := nameWidth - runewidth.StringWidth(name)
+		if branchSuffix != "" && remaining > 3 {
+			branchSuffix = truncate(branchSuffix, remaining)
+		} else {
+			branchSuffix = ""
+		}
+
+		paddedName := padRight(name+branchSuffix, nameWidth)
+
+		var styledName string
+		if branchSuffix != "" {
+			nameOnly := padRight(name, nameWidth-runewidth.StringWidth(branchSuffix))
+			if m.filterText != "" {
+				styledName = highlightMatch(nameOnly, m.filterText, style, filterMatchStyle) + branchStyle.Render(branchSuffix)
+			} else {
+				styledName = style.Render(nameOnly) + branchStyle.Render(branchSuffix)
+			}
+		} else {
+			styledName = style.Render(paddedName)
+			if m.filterText != "" {
+				styledName = highlightMatch(paddedName, m.filterText, style, filterMatchStyle)
+			}
 		}
 
 		row := fmt.Sprintf("%s%s %s %s", indicator, styledName, uptimeStr, clientLabel)
@@ -708,6 +834,47 @@ func (m Model) renderSimplifiedHelp() string {
 	return strings.Join(lines, "\n")
 }
 
+func (m *Model) renderGroupPreview(groupName string, width int) string {
+	var lines []string
+	lines = append(lines, agentStateStyle.Render("sessions"))
+
+	// Find all sessions in this group.
+	for _, s := range m.sessions {
+		if s.GitRepoName != groupName {
+			continue
+		}
+		branch := s.GitBranchName
+		if branch == "" {
+			branch = "-"
+		}
+		status := "idle"
+		if s.Clients > 0 {
+			status = fmt.Sprintf("attached (%d)", s.Clients)
+		}
+		if s.AgentKind != "" {
+			state := s.AgentState
+			if state == "" {
+				state = "running"
+			}
+			status = s.AgentKind + " " + state
+		}
+		line := fmt.Sprintf("  %-14s %s", branch, agentMetaStyle.Render(status))
+		lines = append(lines, line)
+	}
+
+	// Show repo root if available.
+	for _, s := range m.sessions {
+		if s.GitRepoName == groupName && s.GitRepoRoot != "" {
+			lines = append(lines, "")
+			lines = append(lines, agentStateStyle.Render("repo"))
+			lines = append(lines, agentMetaStyle.Render("  "+s.GitRepoRoot))
+			break
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 func renderOverviewRows(s Session) []string {
 	rows := []string{}
 	if model := engine.DisplayAgentModel(s.AgentKind, s.AgentModel); model != "" {
@@ -716,8 +883,15 @@ func renderOverviewRows(s Session) []string {
 	if s.AgentVersion != "" {
 		rows = append(rows, "version: "+s.AgentVersion)
 	}
-	if s.AgentBranch != "" {
-		rows = append(rows, "branch: "+s.AgentBranch)
+	branch := s.AgentBranch
+	if branch == "" {
+		branch = s.GitBranchName
+	}
+	if branch != "" {
+		rows = append(rows, "branch: "+branch)
+	}
+	if s.GitRepoName != "" {
+		rows = append(rows, "repo: "+s.GitRepoName)
 	}
 	if s.AgentName != "" {
 		label := "agent: " + s.AgentName
@@ -738,8 +912,12 @@ func renderOverviewRows(s Session) []string {
 	if s.AgentProjectDir != "" {
 		rows = append(rows, "project: "+s.AgentProjectDir)
 	}
-	if s.AgentWorktreePath != "" {
-		rows = append(rows, "worktree: "+s.AgentWorktreePath)
+	worktree := s.AgentWorktreePath
+	if worktree == "" && s.GitIsWorktree {
+		worktree = s.GitRepoRoot
+	}
+	if worktree != "" {
+		rows = append(rows, "worktree: "+worktree)
 	}
 	return rows
 }

--- a/internal/tui/options.go
+++ b/internal/tui/options.go
@@ -63,11 +63,13 @@ func ParseKeymap(raw string) (Keymap, error) {
 }
 
 type Options struct {
-	Mode        Mode
-	Keymap      Keymap
-	ShowHelp    bool
-	ShowHelpSet bool
-	Bindings    Bindings
+	Mode           Mode
+	Keymap         Keymap
+	ShowHelp       bool
+	ShowHelpSet    bool
+	Bindings       Bindings
+	CurrentSession string // name of the session we're inside (from $TSM_SESSION)
+	FilterRepo     string // if set, only show sessions for this git repo
 }
 
 func NormalizeOptions(opts Options) Options {

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -97,4 +97,16 @@ var (
 	sortStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("75")).
 			Bold(true)
+
+	// Git branch label
+	branchStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("73")) // dim cyan
+
+	// Group header in repo-grouped view
+	groupHeaderStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("75")).
+				Bold(true)
+
+	groupHeaderDimStyle = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("241"))
 )

--- a/main.go
+++ b/main.go
@@ -97,6 +97,8 @@ func main() {
 		cmdDoctor()
 	case "debug":
 		cmdDebug()
+	case "worktree", "wt":
+		cmdWorktree()
 	case "claude-statusline":
 		cmdClaudeStatusline()
 	case "mux", "m":
@@ -143,22 +145,26 @@ func cmdAttach() {
 		}
 		switch len(sessions) {
 		case 0:
-			name, err := suggestSessionName(cfg, sessions)
+			result, err := suggestSessionName(cfg, sessions)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "Error creating session name: %v\n", err)
 				os.Exit(1)
 			}
-			if err := attachSession(cfg, name, true); err != nil {
-				fmt.Fprintln(os.Stderr, formatSessionActionError("attach", name, err))
-				os.Exit(1)
+			if result.Git.IsGitRepo {
+				_ = session.WriteGitMeta(cfg, result.Name, result.Git)
+				if cwd, err := os.Getwd(); err == nil {
+					autoCreateWorktreeSessions(cfg, cwd, result.Git)
+				}
 			}
-			fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", name)
+			if err := attachSession(cfg, result.Name, true); err != nil {
+				handleAttachError(result.Name, err)
+			}
+			fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", result.Name)
 			return
 		case 1:
 			name := sessions[0].Name
 			if err := attachSession(cfg, name, false); err != nil {
-				fmt.Fprintln(os.Stderr, formatSessionActionError("attach", name, err))
-				os.Exit(1)
+				handleAttachError(name, err)
 			}
 			fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", name)
 			return
@@ -177,16 +183,7 @@ func cmdAttach() {
 		return
 	}
 	if err := attachSession(cfg, name, true); err != nil {
-		var switchErr *session.SwitchSessionError
-		if errors.As(err, &switchErr) {
-			if err := execAttachTarget(switchErr.Target); err != nil {
-				fmt.Fprintf(os.Stderr, "Switch error: %v\n", err)
-				os.Exit(1)
-			}
-			return
-		}
-		fmt.Fprintln(os.Stderr, formatSessionActionError("attach", name, err))
-		os.Exit(1)
+		handleAttachError(name, err)
 	}
 	fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", name)
 }
@@ -203,16 +200,7 @@ func cmdToggle() {
 		return
 	}
 	if err := attachSession(cfg, target, false); err != nil {
-		var switchErr *session.SwitchSessionError
-		if errors.As(err, &switchErr) {
-			if err := execAttachTarget(switchErr.Target); err != nil {
-				fmt.Fprintf(os.Stderr, "Switch error: %v\n", err)
-				os.Exit(1)
-			}
-			return
-		}
-		fmt.Fprintln(os.Stderr, formatSessionActionError("attach", target, err))
-		os.Exit(1)
+		handleAttachError(target, err)
 	}
 	fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", target)
 }
@@ -245,6 +233,28 @@ func cmdConfig() {
 		printConfigUsage()
 		os.Exit(1)
 	}
+}
+
+// handleAttachError handles errors from attachSession, including session
+// switches triggered by escape sequences from inside the session, and
+// picker requests triggered by Ctrl+].
+func handleAttachError(name string, err error) {
+	var switchErr *session.SwitchSessionError
+	if errors.As(err, &switchErr) {
+		if err := execAttachTarget(switchErr.Target); err != nil {
+			fmt.Fprintf(os.Stderr, "Switch error: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	var pickerErr *session.PickerRequestError
+	if errors.As(err, &pickerErr) {
+		// Launch TUI picker, then attach to the selected session.
+		launchTUI(mustResolveTUIOptions(nil))
+		return
+	}
+	fmt.Fprintln(os.Stderr, formatSessionActionError("attach", name, err))
+	os.Exit(1)
 }
 
 func emitLocalSwitchRequest(target string) bool {
@@ -308,6 +318,13 @@ func attachSession(cfg session.Config, name string, createIfMissing bool) error 
 			if err := session.SpawnDaemon(name, nil); err != nil {
 				return fmt.Errorf("create session %q: %w", name, err)
 			}
+			// Write git metadata sidecar and auto-create sibling worktree sessions.
+			if cwd, err := os.Getwd(); err == nil {
+				if gitCtx := session.DetectGitContext(cwd); gitCtx.IsGitRepo {
+					_ = session.WriteGitMeta(cfg, name, gitCtx)
+					autoCreateWorktreeSessions(cfg, cwd, gitCtx)
+				}
+			}
 		}
 	} else if !session.IsSocket(path) {
 		return fmt.Errorf("%w: %q", session.ErrSessionNotFound, name)
@@ -329,11 +346,19 @@ func daemonBuildWarning(cfg session.Config, name string) string {
 	return fmt.Sprintf("Warning: session %q is running an older tsm daemon build.\nRecreate the session to pick up the latest session logic if behavior looks stale.", name)
 }
 
-func suggestSessionName(cfg session.Config, sessions []session.Session) (string, error) {
+type sessionNameResult struct {
+	Name string
+	Git  session.GitContext
+}
+
+func suggestSessionName(cfg session.Config, sessions []session.Session) (sessionNameResult, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return sessionNameResult{}, err
 	}
+
+	gitCtx := session.DetectGitContext(cwd)
+
 	base := filepath.Base(cwd)
 	if base == "." || base == string(filepath.Separator) || base == "" {
 		base = "shell"
@@ -341,6 +366,11 @@ func suggestSessionName(cfg session.Config, sessions []session.Session) (string,
 	base = sanitizeSessionName(base)
 	if base == "" {
 		base = "shell"
+	}
+
+	// For linked worktrees, use repo@branch naming.
+	if gitCtx.IsGitRepo && gitCtx.IsWorktree && gitCtx.BranchName != "" {
+		base = session.FormatSessionName(gitCtx)
 	}
 
 	existing := make(map[string]struct{}, len(sessions))
@@ -354,7 +384,7 @@ func suggestSessionName(cfg session.Config, sessions []session.Session) (string,
 
 	base = truncateSessionName(base, maxLen)
 	if _, ok := existing[base]; !ok && socketPathAvailable(cfg, base) {
-		return base, nil
+		return sessionNameResult{Name: base, Git: gitCtx}, nil
 	}
 
 	for i := 2; i < 10000; i++ {
@@ -365,10 +395,10 @@ func suggestSessionName(cfg session.Config, sessions []session.Session) (string,
 			candidate = truncateSessionName(candidate, maxLen)
 		}
 		if _, ok := existing[candidate]; !ok && socketPathAvailable(cfg, candidate) {
-			return candidate, nil
+			return sessionNameResult{Name: candidate, Git: gitCtx}, nil
 		}
 	}
-	return "", fmt.Errorf("could not generate unique session name")
+	return sessionNameResult{}, fmt.Errorf("could not generate unique session name")
 }
 
 func socketPathAvailable(cfg session.Config, name string) bool {
@@ -405,6 +435,13 @@ func cmdNew() {
 	if err := session.SpawnDaemon(name, shellCmd); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
+	}
+	// Write git metadata sidecar for the new session.
+	cfg := session.DefaultConfig()
+	if cwd, err := os.Getwd(); err == nil {
+		if gitCtx := session.DetectGitContext(cwd); gitCtx.IsGitRepo {
+			_ = session.WriteGitMeta(cfg, name, gitCtx)
+		}
 	}
 	fmt.Printf("Session %q created\n", name)
 }
@@ -444,16 +481,38 @@ func cmdList() {
 		return
 	}
 
+	// Check if any session has git metadata to decide whether to show the BRANCH column.
+	hasGit := false
+	for _, s := range sessions {
+		if s.GitBranchName != "" {
+			hasGit = true
+			break
+		}
+	}
+
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "NAME\tPID\tATTACHED\tUPTIME\tCMD\tDIR")
+	if hasGit {
+		fmt.Fprintln(w, "NAME\tBRANCH\tPID\tATTACHED\tUPTIME\tCMD\tDIR")
+	} else {
+		fmt.Fprintln(w, "NAME\tPID\tATTACHED\tUPTIME\tCMD\tDIR")
+	}
 	for _, s := range sessions {
 		uptime := formatUptime(s.CreatedAt)
 		attached := "-"
 		if s.Clients > 0 {
 			attached = fmt.Sprintf("yes (%d)", s.Clients)
 		}
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
-			s.Name, s.PID, attached, uptime, s.Cmd, s.DisplayDir())
+		if hasGit {
+			branch := s.GitBranchName
+			if branch == "" {
+				branch = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				s.Name, branch, s.PID, attached, uptime, s.Cmd, s.DisplayDir())
+		} else {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				s.Name, s.PID, attached, uptime, s.Cmd, s.DisplayDir())
+		}
 	}
 	w.Flush()
 }
@@ -573,6 +632,601 @@ func cmdKill() {
 	}
 }
 
+// autoCreateWorktreeSessions detects sibling worktrees and creates sessions
+// for any that don't already have one. Runs silently — errors are ignored
+// since this is a best-effort convenience feature.
+func autoCreateWorktreeSessions(cfg session.Config, cwd string, gitCtx session.GitContext) {
+	worktrees := parseGitWorktrees(cwd)
+	if len(worktrees) <= 1 {
+		return // no sibling worktrees
+	}
+
+	sessions, err := session.ListSessions(cfg)
+	if err != nil {
+		return
+	}
+	existingByName := make(map[string]bool, len(sessions))
+	existingByDir := make(map[string]bool, len(sessions))
+	for _, s := range sessions {
+		existingByName[s.Name] = true
+		existingByDir[s.StartedIn] = true
+	}
+
+	for _, wt := range worktrees {
+		if wt.Branch == "" {
+			continue
+		}
+		if existingByDir[wt.Path] {
+			continue
+		}
+		wtCtx := session.GitContext{
+			RepoName:   gitCtx.RepoName,
+			BranchName: wt.Branch,
+			IsWorktree: true,
+			IsGitRepo:  true,
+			RepoRoot:   gitCtx.RepoRoot,
+		}
+		name := session.FormatSessionName(wtCtx)
+		if existingByName[name] {
+			continue
+		}
+		if err := session.SpawnDaemonInDir(name, nil, wt.Path); err != nil {
+			continue
+		}
+		_ = session.WriteGitMeta(cfg, name, wtCtx)
+		existingByName[name] = true
+		fmt.Fprintf(os.Stderr, "Auto-created session %q for worktree %s\n", name, wt.Branch)
+	}
+}
+
+func cmdWorktree() {
+	args := os.Args[2:]
+
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h" || args[0] == "help") {
+		printWorktreeUsage()
+		return
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	gitCtx := session.DetectGitContext(cwd)
+	if !gitCtx.IsGitRepo {
+		fmt.Fprintln(os.Stderr, "Error: not inside a git repository")
+		os.Exit(1)
+	}
+
+	// Route subcommands.
+	if len(args) > 0 {
+		switch args[0] {
+		case "add":
+			cmdWorktreeAdd(cwd, gitCtx, args[1:])
+			return
+		case "rm", "remove":
+			cmdWorktreeRemove(cwd, gitCtx, args[1:])
+			return
+		case "move", "mv":
+			cmdWorktreeMove(cwd, gitCtx, args[1:])
+			return
+		case "prune":
+			if len(args) > 1 && (args[1] == "--help" || args[1] == "-h") {
+				printWorktreePruneUsage()
+				return
+			}
+			cmdWorktreePrune(cwd, gitCtx)
+			return
+		case "tui":
+			opts := mustResolveTUIOptions(args[1:])
+			opts.FilterRepo = gitCtx.RepoName
+			launchTUI(opts)
+			return
+		}
+	}
+
+	cfg := session.DefaultConfig()
+	sessions, _ := session.ListSessions(cfg)
+	sessionByDir, sessionByName := buildSessionMaps(sessions)
+
+	// Handle flags and branch target.
+	createAll := false
+	var targetBranch string
+	for _, arg := range args {
+		switch arg {
+		case "--create", "-c":
+			createAll = true
+		default:
+			if strings.HasPrefix(arg, "-") {
+				fmt.Fprintf(os.Stderr, "tsm wt: unknown option %q\n", arg)
+				printWorktreeUsage()
+				os.Exit(1)
+			}
+			targetBranch = arg
+		}
+	}
+
+	worktrees := parseGitWorktrees(cwd)
+
+	if targetBranch != "" {
+		cmdWorktreeAttach(cfg, gitCtx, worktrees, sessionByName, targetBranch)
+		return
+	}
+
+	if createAll {
+		cmdWorktreeCreateAll(cfg, gitCtx, worktrees, sessionByName, sessionByDir)
+		return
+	}
+
+	// Default: list worktrees and their session status.
+	if len(worktrees) == 0 {
+		fmt.Println("No worktrees found. Use 'tsm wt add <branch>' to create one.")
+		return
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "BRANCH\tPATH\tSESSION\tSTATUS")
+	for _, wt := range worktrees {
+		branchDisplay := wt.Branch
+		if branchDisplay == "" {
+			branchDisplay = wt.HEAD
+			if len(branchDisplay) > 8 {
+				branchDisplay = branchDisplay[:8]
+			}
+		}
+
+		// Shorten path relative to parent of current repo.
+		pathDisplay := wt.Path
+		if parent := filepath.Dir(cwd); strings.HasPrefix(wt.Path, parent) {
+			pathDisplay = "." + wt.Path[len(parent):]
+		}
+
+		sessionName := "-"
+		status := "no session"
+		expectedName := worktreeSessionName(gitCtx, wt.Branch)
+		if s, ok := sessionByName[expectedName]; ok {
+			sessionName = s.Name
+			status = sessionStatus(s)
+		} else if s, ok := sessionByDir[wt.Path]; ok {
+			sessionName = s.Name
+			status = sessionStatus(s)
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", branchDisplay, pathDisplay, sessionName, status)
+	}
+	w.Flush()
+}
+
+func cmdWorktreeAdd(cwd string, gitCtx session.GitContext, args []string) {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		printWorktreeAddUsage()
+		if len(args) == 0 {
+			os.Exit(1)
+		}
+		return
+	}
+
+	cfg := session.DefaultConfig()
+	for _, branch := range args {
+		wtPath := filepath.Join(filepath.Dir(cwd), gitCtx.RepoName+"-"+session.SanitizeBranch(branch))
+
+		branchExists := exec.Command("git", "-C", cwd, "rev-parse", "--verify", branch).Run() == nil
+
+		var gitArgs []string
+		if branchExists {
+			gitArgs = []string{"-C", cwd, "worktree", "add", wtPath, branch}
+		} else {
+			gitArgs = []string{"-C", cwd, "worktree", "add", wtPath, "-b", branch}
+		}
+
+		cmd := exec.Command("git", gitArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating worktree %q: %v\n", branch, err)
+			continue
+		}
+
+		wtCtx := session.GitContext{
+			RepoName:   gitCtx.RepoName,
+			BranchName: branch,
+			IsWorktree: true,
+			IsGitRepo:  true,
+			RepoRoot:   gitCtx.RepoRoot,
+		}
+		sessionName := session.FormatSessionName(wtCtx)
+
+		if err := session.SpawnDaemonInDir(sessionName, nil, wtPath); err != nil {
+			fmt.Fprintf(os.Stderr, "Worktree %q created but session failed: %v\n", branch, err)
+			continue
+		}
+		_ = session.WriteGitMeta(cfg, sessionName, wtCtx)
+		fmt.Printf("Created worktree %q at %s with session %q\n", branch, wtPath, sessionName)
+	}
+}
+
+func cmdWorktreeRemove(cwd string, gitCtx session.GitContext, args []string) {
+	if len(args) == 0 || args[0] == "--help" || args[0] == "-h" {
+		printWorktreeRemoveUsage()
+		if len(args) == 0 {
+			os.Exit(1)
+		}
+		return
+	}
+
+	force := false
+	var branches []string
+	for _, arg := range args {
+		if arg == "--force" || arg == "-f" {
+			force = true
+		} else {
+			branches = append(branches, arg)
+		}
+	}
+	if len(branches) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: tsm wt rm <branch...> [-f]")
+		os.Exit(1)
+	}
+
+	worktrees := parseGitWorktrees(cwd)
+	cfg := session.DefaultConfig()
+
+	for _, branch := range branches {
+		var target *gitWorktree
+		for i, wt := range worktrees {
+			if wt.Branch == branch || session.SanitizeBranch(wt.Branch) == branch {
+				target = &worktrees[i]
+				break
+			}
+		}
+		if target == nil {
+			fmt.Fprintf(os.Stderr, "No worktree found for branch %q\n", branch)
+			continue
+		}
+
+		// Kill the session if it exists.
+		sessionName := worktreeSessionName(gitCtx, target.Branch)
+		if err := session.KillSession(cfg, sessionName); err == nil {
+			fmt.Printf("Killed session %q\n", sessionName)
+		}
+		_ = session.RemoveSessionArtifacts(cfg, sessionName)
+
+		// Remove the git worktree.
+		gitArgs := []string{"-C", cwd, "worktree", "remove", target.Path}
+		if force {
+			gitArgs = []string{"-C", cwd, "worktree", "remove", "--force", target.Path}
+		}
+		cmd := exec.Command("git", gitArgs...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error removing worktree %q: %v\n", branch, err)
+			continue
+		}
+		fmt.Printf("Removed worktree %q\n", branch)
+	}
+}
+
+func cmdWorktreeMove(cwd string, gitCtx session.GitContext, args []string) {
+	if len(args) < 2 || args[0] == "--help" || args[0] == "-h" {
+		printWorktreeMoveUsage()
+		if len(args) < 2 {
+			os.Exit(1)
+		}
+		return
+	}
+
+	branch := args[0]
+	newPath := args[1]
+	if !filepath.IsAbs(newPath) {
+		newPath = filepath.Join(cwd, newPath)
+	}
+
+	// Find the worktree for this branch.
+	worktrees := parseGitWorktrees(cwd)
+	var target *gitWorktree
+	for i, wt := range worktrees {
+		if wt.Branch == branch || session.SanitizeBranch(wt.Branch) == branch {
+			target = &worktrees[i]
+			break
+		}
+	}
+	if target == nil {
+		fmt.Fprintf(os.Stderr, "No worktree found for branch %q\n", branch)
+		os.Exit(1)
+	}
+
+	cmd := exec.Command("git", "-C", cwd, "worktree", "move", target.Path, newPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error moving worktree: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Update the session's git metadata with the new path.
+	cfg := session.DefaultConfig()
+	sessionName := worktreeSessionName(gitCtx, target.Branch)
+	if meta, err := session.ReadGitMeta(cfg, sessionName); err == nil {
+		meta.RepoRoot = gitCtx.RepoRoot
+		_ = session.WriteGitMeta(cfg, sessionName, meta)
+	}
+
+	fmt.Printf("Moved worktree %q to %s\n", branch, newPath)
+}
+
+func cmdWorktreePrune(cwd string, gitCtx session.GitContext) {
+	// First, find worktrees that git considers stale.
+	cmd := exec.Command("git", "-C", cwd, "worktree", "prune", "--verbose")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error pruning worktrees: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Clean up orphaned sessions — sessions with git metadata pointing
+	// to worktree paths that no longer exist.
+	cfg := session.DefaultConfig()
+	sessions, err := session.ListSessions(cfg)
+	if err != nil {
+		return
+	}
+
+	liveWorktrees := parseGitWorktrees(cwd)
+	livePaths := make(map[string]bool, len(liveWorktrees))
+	for _, wt := range liveWorktrees {
+		livePaths[wt.Path] = true
+	}
+
+	cleaned := 0
+	for _, s := range sessions {
+		if s.GitRepoName != gitCtx.RepoName || !s.GitIsWorktree {
+			continue
+		}
+		// Check if this session's worktree still exists.
+		if s.StartedIn != "" && !livePaths[s.StartedIn] {
+			if err := session.KillSession(cfg, s.Name); err == nil {
+				_ = session.RemoveSessionArtifacts(cfg, s.Name)
+				fmt.Printf("Cleaned up orphaned session %q\n", s.Name)
+				cleaned++
+			}
+		}
+	}
+	if cleaned == 0 {
+		fmt.Println("No orphaned sessions found")
+	}
+}
+
+func cmdWorktreeAttach(cfg session.Config, gitCtx session.GitContext, worktrees []gitWorktree, sessionByName map[string]session.Session, targetBranch string) {
+	for _, wt := range worktrees {
+		if wt.Branch == targetBranch || session.SanitizeBranch(wt.Branch) == targetBranch {
+			sessionName := worktreeSessionName(gitCtx, wt.Branch)
+			if s, ok := sessionByName[sessionName]; ok {
+				if switched := emitLocalSwitchRequest(s.Name); switched {
+					return
+				}
+				if err := attachSession(cfg, s.Name, false); err != nil {
+					handleAttachError(s.Name, err)
+				}
+				fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", s.Name)
+				return
+			}
+			// Create a new session in the worktree directory.
+			wtCtx := session.GitContext{
+				RepoName:   gitCtx.RepoName,
+				BranchName: wt.Branch,
+				IsWorktree: true,
+				IsGitRepo:  true,
+				RepoRoot:   gitCtx.RepoRoot,
+			}
+			if err := session.SpawnDaemonInDir(sessionName, nil, wt.Path); err != nil {
+				fmt.Fprintf(os.Stderr, "Error creating session: %v\n", err)
+				os.Exit(1)
+			}
+			_ = session.WriteGitMeta(cfg, sessionName, wtCtx)
+			fmt.Printf("Session %q created for worktree %s\n", sessionName, wt.Branch)
+			if switched := emitLocalSwitchRequest(sessionName); switched {
+				return
+			}
+			if err := attachSession(cfg, sessionName, false); err != nil {
+				handleAttachError(sessionName, err)
+			}
+			fmt.Fprintf(os.Stdout, "\r\n[detached from %s]\r\n", sessionName)
+			return
+		}
+	}
+	fmt.Fprintf(os.Stderr, "No worktree found for branch %q\n", targetBranch)
+	os.Exit(1)
+}
+
+func cmdWorktreeCreateAll(cfg session.Config, gitCtx session.GitContext, worktrees []gitWorktree, sessionByName map[string]session.Session, sessionByDir map[string]session.Session) {
+	created := 0
+	for _, wt := range worktrees {
+		if wt.Branch == "" {
+			continue
+		}
+		sessionName := worktreeSessionName(gitCtx, wt.Branch)
+		if _, ok := sessionByName[sessionName]; ok {
+			continue
+		}
+		if _, ok := sessionByDir[wt.Path]; ok {
+			continue
+		}
+		wtCtx := session.GitContext{
+			RepoName:   gitCtx.RepoName,
+			BranchName: wt.Branch,
+			IsWorktree: true,
+			IsGitRepo:  true,
+			RepoRoot:   gitCtx.RepoRoot,
+		}
+		if err := session.SpawnDaemonInDir(sessionName, nil, wt.Path); err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating session %q: %v\n", sessionName, err)
+			continue
+		}
+		_ = session.WriteGitMeta(cfg, sessionName, wtCtx)
+		fmt.Printf("Created session %q (%s)\n", sessionName, wt.Branch)
+		created++
+	}
+	if created == 0 {
+		fmt.Println("All worktrees already have sessions")
+	}
+}
+
+// Helpers
+
+func worktreeSessionName(gitCtx session.GitContext, branch string) string {
+	return session.FormatSessionName(session.GitContext{
+		RepoName:   gitCtx.RepoName,
+		BranchName: branch,
+		IsWorktree: true,
+		IsGitRepo:  true,
+		RepoRoot:   gitCtx.RepoRoot,
+	})
+}
+
+func sessionStatus(s session.Session) string {
+	if s.Clients > 0 {
+		return fmt.Sprintf("attached (%d)", s.Clients)
+	}
+	return "idle"
+}
+
+func buildSessionMaps(sessions []session.Session) (byDir, byName map[string]session.Session) {
+	byDir = make(map[string]session.Session, len(sessions))
+	byName = make(map[string]session.Session, len(sessions))
+	for _, s := range sessions {
+		byDir[s.StartedIn] = s
+		byName[s.Name] = s
+	}
+	return
+}
+
+type gitWorktree struct {
+	Path   string
+	HEAD   string
+	Branch string
+}
+
+func parseGitWorktrees(cwd string) []gitWorktree {
+	out, err := exec.Command("git", "-C", cwd, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		return nil
+	}
+
+	var worktrees []gitWorktree
+	var current gitWorktree
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "worktree "):
+			if current.Path != "" {
+				worktrees = append(worktrees, current)
+			}
+			current = gitWorktree{Path: strings.TrimPrefix(line, "worktree ")}
+		case strings.HasPrefix(line, "HEAD "):
+			current.HEAD = strings.TrimPrefix(line, "HEAD ")
+		case strings.HasPrefix(line, "branch refs/heads/"):
+			current.Branch = strings.TrimPrefix(line, "branch refs/heads/")
+		case strings.HasPrefix(line, "branch "):
+			current.Branch = strings.TrimPrefix(line, "branch ")
+		}
+	}
+	if current.Path != "" {
+		worktrees = append(worktrees, current)
+	}
+	return worktrees
+}
+
+func printWorktreeUsage() {
+	fmt.Print(`tsm worktree — manage git worktrees and their sessions
+
+Usage:
+  tsm wt                           List worktrees and their session status
+  tsm wt <branch>                  Attach to (or create) session for a branch
+  tsm wt tui                       Open TUI filtered to this repo's worktrees
+  tsm wt add <branch...>           Create new worktrees + sessions
+  tsm wt rm <branch...> [-f]       Remove worktrees and kill their sessions
+  tsm wt move <branch> <path>      Move a worktree to a new path
+  tsm wt prune                     Prune stale worktrees and orphaned sessions
+  tsm wt --create                  Create sessions for all existing worktrees
+  tsm wt help                      Show this help
+
+Examples:
+  tsm wt                                List all worktrees and sessions
+  tsm wt feature-login                  Attach to worktree session
+  tsm wt add feature-login              Create worktree as sibling directory
+  tsm wt add feat-1 feat-2 feat-3       Create multiple worktrees at once
+  tsm wt rm feature-login               Remove worktree and session
+  tsm wt rm feat-1 feat-2 -f            Force remove multiple worktrees
+  tsm wt move feature-login ../newdir   Move worktree directory
+  tsm wt prune                          Clean up stale worktrees + sessions
+  tsm wt --create                       Create sessions for all worktrees
+
+Aliases: worktree=wt  rm=remove  move=mv
+`)
+}
+
+func printWorktreeAddUsage() {
+	fmt.Print(`tsm wt add — create git worktrees with sessions
+
+Usage:
+  tsm wt add <branch...>
+
+Creates a new git worktree for each branch and spawns a tsm session in it.
+If the branch exists, it checks it out. If not, it creates a new branch.
+The worktree is placed as a sibling directory: ../<repo>-<branch>
+
+Examples:
+  tsm wt add feature-login             Single worktree
+  tsm wt add feat-1 feat-2 feat-3      Multiple worktrees
+`)
+}
+
+func printWorktreeRemoveUsage() {
+	fmt.Print(`tsm wt rm — remove git worktrees and their sessions
+
+Usage:
+  tsm wt rm <branch...> [-f]
+
+Kills the tsm session for each branch (if running), then removes the
+git worktree. Use -f/--force to remove worktrees with uncommitted changes.
+
+Examples:
+  tsm wt rm feature-login              Remove one worktree
+  tsm wt rm feat-1 feat-2              Remove multiple
+  tsm wt rm feat-1 feat-2 -f           Force remove (uncommitted changes)
+
+Aliases: rm=remove
+`)
+}
+
+func printWorktreeMoveUsage() {
+	fmt.Print(`tsm wt move — move a git worktree to a new path
+
+Usage:
+  tsm wt move <branch> <new-path>
+
+Moves the worktree directory and updates session metadata.
+
+Examples:
+  tsm wt move feature-login ../new-location
+
+Aliases: move=mv
+`)
+}
+
+func printWorktreePruneUsage() {
+	fmt.Print(`tsm wt prune — clean up stale worktrees and orphaned sessions
+
+Usage:
+  tsm wt prune
+
+Runs 'git worktree prune' to remove stale worktree references, then
+finds and kills tsm sessions whose worktree directories no longer exist.
+`)
+}
+
 func resolveKillTargets(args []string) []string {
 	if len(args) >= 3 {
 		return args[2:]
@@ -601,7 +1255,9 @@ func resolveTUIOptions(args []string, getenv func(string) string) (tui.Options, 
 }
 
 func resolveTUIOptionsWithConfig(args []string, getenv func(string) string, cfg appconfig.Config) (tui.Options, error) {
-	opts := tui.Options{}
+	opts := tui.Options{
+		CurrentSession: getenv("TSM_SESSION"),
+	}
 
 	if raw := cfg.TUI.Mode; raw != "" {
 		mode, err := tui.ParseMode(raw)
@@ -688,8 +1344,13 @@ func launchTUI(opts tui.Options) {
 		AttachTarget() string
 	}
 	if m, ok := finalModel.(attachTargeter); ok && m.AttachTarget() != "" {
-		_ = markSessionFocused(session.DefaultConfig(), m.AttachTarget(), os.Getenv("TSM_SESSION"))
-		if err := runAttachTarget(m.AttachTarget()); err != nil {
+		target := m.AttachTarget()
+		_ = markSessionFocused(session.DefaultConfig(), target, os.Getenv("TSM_SESSION"))
+
+		// Replace the current process with `tsm attach <target>`.
+		// This avoids TUI cleanup output interfering with the
+		// session switch escape sequence.
+		if err := execAttachTarget(target); err != nil {
 			fmt.Fprintf(os.Stderr, "Attach error: %v\n", err)
 			os.Exit(1)
 		}
@@ -1613,6 +2274,12 @@ Usage:
   tsm list                     List active sessions
   tsm rename <old> <new>       Rename a session
   tsm kill [name...]           Kill current or named sessions
+  tsm wt                       List worktrees and session status
+  tsm wt <branch>              Attach/create session for a worktree
+  tsm wt add <branch> [path]   Create a new worktree + session
+  tsm wt rm <branch>           Remove a worktree and its session
+  tsm wt move <branch> <path>  Move a worktree to a new path
+  tsm wt prune                 Prune stale worktrees + sessions
   tsm mux open <workspace>     Open workspace from manifest
   tsm mux new <workspace>      Create a new workspace manifest
   tsm mux edit                 Open workspace dir in $EDITOR
@@ -1633,7 +2300,7 @@ Usage:
 
 Aliases:
   palette=p  attach=a  detach=d  new=n  list=l,ls
-  rename=mv  kill=k  mux=m  version=v  help=h
+  rename=mv  kill=k  mux=m  worktree=wt  version=v  help=h
 
 Detach from a session with Ctrl+\
 `)

--- a/main_test.go
+++ b/main_test.go
@@ -26,12 +26,12 @@ func TestSuggestSessionNameUsesCurrentDirectory(t *testing.T) {
 	t.Chdir(workdir)
 
 	cfg := session.DefaultConfig()
-	name, err := suggestSessionName(cfg, nil)
+	result, err := suggestSessionName(cfg, nil)
 	if err != nil {
 		t.Fatalf("suggestSessionName: %v", err)
 	}
-	if name != "demo" {
-		t.Fatalf("name = %q, want demo", name)
+	if result.Name != "demo" {
+		t.Fatalf("name = %q, want demo", result.Name)
 	}
 }
 
@@ -45,12 +45,12 @@ func TestSuggestSessionNameAddsSuffixForCollisions(t *testing.T) {
 
 	cfg := session.DefaultConfig()
 	sessions := []session.Session{{Name: "demo"}, {Name: "demo-2"}}
-	name, err := suggestSessionName(cfg, sessions)
+	result, err := suggestSessionName(cfg, sessions)
 	if err != nil {
 		t.Fatalf("suggestSessionName: %v", err)
 	}
-	if name != "demo-3" {
-		t.Fatalf("name = %q, want demo-3", name)
+	if result.Name != "demo-3" {
+		t.Fatalf("name = %q, want demo-3", result.Name)
 	}
 }
 
@@ -63,15 +63,15 @@ func TestSuggestSessionNameSkipsExistingSocketPathConflicts(t *testing.T) {
 	t.Chdir(workdir)
 
 	cfg := session.Config{SocketDir: dir}
-	name, err := suggestSessionName(cfg, nil)
+	result, err := suggestSessionName(cfg, nil)
 	if err != nil {
 		t.Fatalf("suggestSessionName: %v", err)
 	}
-	if name == "demo" {
-		t.Fatalf("name = %q, want conflict-avoiding variant", name)
+	if result.Name == "demo" {
+		t.Fatalf("name = %q, want conflict-avoiding variant", result.Name)
 	}
-	if !strings.HasSuffix(name, "-2") {
-		t.Fatalf("name = %q, want suffix -2", name)
+	if !strings.HasSuffix(result.Name, "-2") {
+		t.Fatalf("name = %q, want suffix -2", result.Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Git-aware session naming**: sessions in linked worktrees auto-name as `repo@branch` (e.g., `myapp@feature-login`)
- **TUI grouping**: default sort groups sessions by repo with collapsible headers, filter matches branch/repo, `Ctrl+]` opens picker from any app
- **`tsm wt` command**: full worktree lifecycle — `add`, `rm`, `move`, `prune`, `tui`, auto-create sibling sessions
- **Switching fixes**: all attach paths handle `SwitchSessionError` consistently, no more "Cannot attach" errors

## What it looks like

Sessions grouped by repo in the TUI:
```
  ▾ myapp (3)
  ▸ myapp@main          ●1  2h
    myapp@feature-x     ○0  30m
    myapp@bugfix-123    ○0  5m
  nvim                  ○0  10m
```

Worktree management:
```
$ tsm wt
BRANCH       PATH              SESSION              STATUS
main         ./myapp           myapp@main            attached (1)
feature-x    ./myapp-feature-x myapp@feature-x       idle
bugfix-123   ./myapp-bugfix    myapp@bugfix-123      idle

$ tsm wt add hotfix-789       # creates worktree + session
$ tsm wt rm feat-1 feat-2     # removes worktrees + kills sessions
$ tsm wt tui                  # TUI filtered to this repo
```

## Test plan

- [ ] Create a git repo with worktrees, verify `tsm attach` auto-names `repo@branch`
- [ ] Verify `tsm wt` lists worktrees with session status
- [ ] Test `tsm wt add/rm` with single and multiple branches
- [ ] Open TUI, verify repo grouping with collapsible headers
- [ ] Test `Ctrl+]` opens picker from inside neovim/full-screen apps
- [ ] Test `tsm wt tui` shows only current repo's sessions
- [ ] Verify simplified/palette mode works without grouping issues
- [ ] Test session switching from TUI works without "Cannot attach" errors